### PR TITLE
Add fullscreen support

### DIFF
--- a/lib/src/models/webviewtube_options.dart
+++ b/lib/src/models/webviewtube_options.dart
@@ -8,6 +8,7 @@ class WebviewtubeOptions {
   /// {@macro webviewtube_options}
   const WebviewtubeOptions({
     this.showControls = true,
+    this.enableFullscreen = true,
     this.mute = false,
     this.loop = false,
     this.forceHd = false,
@@ -26,6 +27,15 @@ class WebviewtubeOptions {
   /// Set to false if you want to use customized controls.
   /// Defaults to true.
   final bool showControls;
+
+  /// Display the fullscreen button in the player controls.
+  ///
+  /// This parameter controls the YouTube IFrame Player API's 'fs' parameter.
+  /// When set to true (default), the fullscreen button will be displayed.
+  /// When set to false, the fullscreen button will be hidden.
+  ///
+  /// Defaults to true.
+  final bool enableFullscreen;
 
   /// Mutes the player after initialization.
   ///
@@ -98,6 +108,7 @@ class WebviewtubeOptions {
 
   WebviewtubeOptions copyWith({
     bool? showControls,
+    bool? enableFullscreen,
     bool? mute,
     bool? loop,
     bool? forceHd,
@@ -112,6 +123,7 @@ class WebviewtubeOptions {
   }) {
     return WebviewtubeOptions(
       showControls: showControls ?? this.showControls,
+      enableFullscreen: enableFullscreen ?? this.enableFullscreen,
       mute: mute ?? this.mute,
       loop: loop ?? this.loop,
       forceHd: forceHd ?? this.forceHd,
@@ -132,6 +144,7 @@ class WebviewtubeOptions {
       other is WebviewtubeOptions &&
       other.runtimeType == runtimeType &&
       other.showControls == showControls &&
+      other.enableFullscreen == enableFullscreen &&
       other.mute == mute &&
       other.loop == loop &&
       other.forceHd == forceHd &&
@@ -148,6 +161,7 @@ class WebviewtubeOptions {
   int get hashCode => Object.hash(
         runtimeType,
         showControls,
+        enableFullscreen,
         mute,
         loop,
         forceHd,
@@ -165,6 +179,7 @@ class WebviewtubeOptions {
   String toString() {
     return 'WebviewtubeOptions('
         'showControls: $showControls, '
+        'enableFullscreen: $enableFullscreen, '
         'mute: $mute, '
         'loop: $loop, '
         'forceHd: $forceHd, '

--- a/lib/src/webviewtube_controller.dart
+++ b/lib/src/webviewtube_controller.dart
@@ -469,7 +469,7 @@ String _generateIframePage(String videoId, WebviewtubeOptions options) {
                     'cc_lang_pref': '${options.captionLanguage}',
                     'controls': ${_boolean(options.showControls)},
                     'enablejsapi': 1,
-                    'fs': 0,
+                    'fs': ${_boolean(options.enableFullscreen)},
                     'hl': '${options.interfaceLanguage}',
                     'iv_load_policy': 3,
                     'loop': ${_boolean(options.loop)},

--- a/test/models/webviewtube_options_test.dart
+++ b/test/models/webviewtube_options_test.dart
@@ -25,6 +25,13 @@ void main() {
         expect(actual, WebviewtubeOptions(showControls: false));
       });
 
+      test('enableFullscreen', () {
+        final actual = options.copyWith(enableFullscreen: false);
+
+        expect(options != actual, true);
+        expect(actual, WebviewtubeOptions(enableFullscreen: false));
+      });
+
       test('mute', () {
         final actual = options.copyWith(mute: true);
 


### PR DESCRIPTION
## Description
This PR adds native fullscreen button support to the YouTube IFrame Player by introducing a new `enableFullscreen` option in `WebviewtubeOptions`.

## Changes
- Added `enableFullscreen` parameter to `WebviewtubeOptions` class (defaults to `true`)
- Updated YouTube IFrame Player API configuration to respect the `enableFullscreen` setting
- Modified the `fs` player parameter from hardcoded `0` to `${_boolean(options.enableFullscreen)}`
- Added test coverage for the new `enableFullscreen` option in `webviewtube_options_test.dart`
- Updated `copyWith`, `operator ==`, `hashCode`, and `toString` methods to include the new parameter

## Motivation
Previously, the fullscreen button was hardcoded to be disabled (`'fs': 0`) in the YouTube IFrame Player. This prevented users from utilizing the native fullscreen functionality provided by YouTube's player controls. This change allows developers to enable/disable the fullscreen button based on their app requirements.

## Usage
```dart
// Enable fullscreen button (default)
WebviewtubeController(
  options: const WebviewtubeOptions(
    enableFullscreen: true,
  ),
);

// Disable fullscreen button
WebviewtubeController(
  options: const WebviewtubeOptions(
    enableFullscreen: false,
  ),
);