### PR TITLE
feat: expose WebviewtubeDefaults for composable overlay builders

### DIFF
--- a/lib/src/webviewtube.dart
+++ b/lib/src/webviewtube.dart
@@ -6,4 +6,5 @@ export 'widgets/widgets.dart'
         WebviewtubeVideoPlayer,
         WebviewtubeLoadingBuilder,
         WebviewtubeControlsBuilder,
-        WebviewtubeProgressBarBuilder;
+        WebviewtubeProgressBarBuilder,
+        WebviewtubeDefaults;

--- a/lib/src/widgets/webviewtube_video_player.dart
+++ b/lib/src/widgets/webviewtube_video_player.dart
@@ -119,16 +119,25 @@ class WebviewtubeVideoPlayer extends StatelessWidget {
     videoId: videoId,
     loadingBuilder:
         loadingBuilder ??
-        (context, isReady) =>
-            _defaultLoadingBuilder(context, isReady, loadingIndicatorColor),
+        (context, isReady) => WebviewtubeDefaults.loadingBuilder(
+          context,
+          isReady,
+          color: loadingIndicatorColor,
+        ),
     controlsBuilder:
         controlsBuilder ??
-        (context, playerState) =>
-            _defaultControlsBuilder(context, playerState, controlsColor),
+        (context, playerState) => WebviewtubeDefaults.controlsBuilder(
+          context,
+          playerState,
+          color: controlsColor,
+        ),
     progressBarBuilder:
         progressBarBuilder ??
-        (context, playerState) =>
-            _defaultProgressBarBuilder(context, playerState, progressBarStyle),
+        (context, playerState) => WebviewtubeDefaults.progressBarBuilder(
+          context,
+          playerState,
+          style: progressBarStyle,
+        ),
   );
 
   @override
@@ -194,15 +203,6 @@ class _WebviewtubeVideoPlayerView extends StatelessWidget {
   }
 }
 
-Widget _defaultLoadingBuilder(
-  BuildContext context,
-  bool isReady, [
-  Color? color,
-]) {
-  if (isReady) return const SizedBox.shrink();
-  return LoadingIndicator(color: color ?? Colors.white);
-}
-
 /// Fades out and disables pointer events while [hide] is true.
 class _HideWhenPlaying extends StatelessWidget {
   const _HideWhenPlaying({required this.hide, required this.child});
@@ -220,54 +220,105 @@ class _HideWhenPlaying extends StatelessWidget {
   }
 }
 
-Widget _defaultControlsBuilder(
-  BuildContext context,
-  PlayerState playerState, [
-  Color? color,
-]) {
-  final textStyle = kDefaultControlTextStyle.copyWith(color: color);
-  final iconColor = textStyle.color ?? Colors.white;
+/// Default builders used by [WebviewtubeVideoPlayer] for its loading,
+/// controls, and progress-bar overlays.
+///
+/// Each method matches the corresponding builder typedef and can be passed
+/// as a tear-off when only the default behavior is wanted:
+///
+/// ```dart
+/// WebviewtubeVideoPlayer(
+///   videoId: '...',
+///   loadingBuilder: WebviewtubeDefaults.loadingBuilder,
+/// );
+/// ```
+///
+/// They can also be composed inside a custom builder to add to or wrap the
+/// default overlay without rewriting it from scratch:
+///
+/// ```dart
+/// controlsBuilder: (ctx, state) => Stack(
+///   clipBehavior: Clip.none,
+///   children: [
+///     WebviewtubeDefaults.controlsBuilder(ctx, state, color: Colors.red),
+///     const Positioned(right: 10, bottom: -5, child: MyExtraButton()),
+///   ],
+/// );
+/// ```
+class WebviewtubeDefaults {
+  WebviewtubeDefaults._();
 
-  if (playerState == PlayerState.ended) {
+  /// Default [WebviewtubeLoadingBuilder]: shows [LoadingIndicator] until the
+  /// player reports ready, then collapses to a zero-size box.
+  ///
+  /// [color] tints the indicator when it's visible; defaults to white.
+  static Widget loadingBuilder(
+    BuildContext context,
+    bool isReady, {
+    Color? color,
+  }) {
+    if (isReady) return const SizedBox.shrink();
+    return LoadingIndicator(color: color ?? Colors.white);
+  }
+
+  /// Default [WebviewtubeControlsBuilder]: shows a replay button when the
+  /// video has ended, and otherwise a row of duration/volume/speed controls
+  /// that fades out while playing.
+  ///
+  /// [color] tints the icons and text; defaults to white.
+  static Widget controlsBuilder(
+    BuildContext context,
+    PlayerState playerState, {
+    Color? color,
+  }) {
+    final textStyle = kDefaultControlTextStyle.copyWith(color: color);
+    final iconColor = textStyle.color ?? Colors.white;
+
+    if (playerState == PlayerState.ended) {
+      return Positioned(
+        left: 10,
+        bottom: -5,
+        child: IconButton(
+          onPressed: () => context.read<WebviewtubeController>().replay(),
+          icon: Icon(Icons.replay, color: iconColor),
+        ),
+      );
+    }
+
     return Positioned(
       left: 10,
       bottom: -5,
-      child: IconButton(
-        onPressed: () => context.read<WebviewtubeController>().replay(),
-        icon: Icon(Icons.replay, color: iconColor),
+      child: _HideWhenPlaying(
+        hide: playerState == PlayerState.playing,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            DurationIndicator(textStyle: textStyle),
+            VolumeButton(color: iconColor),
+            PlaybackSpeedButton(color: iconColor),
+          ],
+        ),
       ),
     );
   }
 
-  return Positioned(
-    left: 10,
-    bottom: -5,
-    child: _HideWhenPlaying(
-      hide: playerState == PlayerState.playing,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          DurationIndicator(textStyle: textStyle),
-          VolumeButton(color: iconColor),
-          PlaybackSpeedButton(color: iconColor),
-        ],
+  /// Default [WebviewtubeProgressBarBuilder]: shows a [ProgressBar] at the
+  /// bottom of the player that fades out while playing.
+  ///
+  /// [style] customizes colors and dimensions; defaults to [ProgressBarStyle].
+  static Widget progressBarBuilder(
+    BuildContext context,
+    PlayerState playerState, {
+    ProgressBarStyle? style,
+  }) {
+    return Positioned(
+      left: 5,
+      right: 5,
+      bottom: 35,
+      child: _HideWhenPlaying(
+        hide: playerState == PlayerState.playing,
+        child: ProgressBar(style: style),
       ),
-    ),
-  );
-}
-
-Widget _defaultProgressBarBuilder(
-  BuildContext context,
-  PlayerState playerState, [
-  ProgressBarStyle? style,
-]) {
-  return Positioned(
-    left: 5,
-    right: 5,
-    bottom: 35,
-    child: _HideWhenPlaying(
-      hide: playerState == PlayerState.playing,
-      child: ProgressBar(style: style),
-    ),
-  );
+    );
+  }
 }

--- a/test/widgets/webviewtube_defaults_test.dart
+++ b/test/widgets/webviewtube_defaults_test.dart
@@ -1,0 +1,101 @@
+// ignore_for_file: prefer_const_declarations
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webviewtube/src/widgets/widgets.dart';
+import 'package:webviewtube/webviewtube.dart' as public;
+
+void main() {
+  group('WebviewtubeDefaults', () {
+    group('loadingBuilder', () {
+      testWidgets('returns SizedBox.shrink when isReady is true', (
+        tester,
+      ) async {
+        late Widget result;
+        await tester.pumpWidget(
+          Builder(
+            builder: (context) {
+              result = WebviewtubeDefaults.loadingBuilder(context, true);
+              return const SizedBox();
+            },
+          ),
+        );
+
+        expect(result, isA<SizedBox>());
+        final sizedBox = result as SizedBox;
+        expect(sizedBox.width, 0);
+        expect(sizedBox.height, 0);
+      });
+
+      testWidgets('returns LoadingIndicator when isReady is false', (
+        tester,
+      ) async {
+        late Widget result;
+        await tester.pumpWidget(
+          Builder(
+            builder: (context) {
+              result = WebviewtubeDefaults.loadingBuilder(context, false);
+              return const SizedBox();
+            },
+          ),
+        );
+
+        expect(result, isA<LoadingIndicator>());
+      });
+
+      testWidgets('respects custom color', (tester) async {
+        late Widget result;
+        await tester.pumpWidget(
+          Builder(
+            builder: (context) {
+              result = WebviewtubeDefaults.loadingBuilder(
+                context,
+                false,
+                color: Colors.red,
+              );
+              return const SizedBox();
+            },
+          ),
+        );
+
+        expect((result as LoadingIndicator).color, Colors.red);
+      });
+
+      test(
+        'matches WebviewtubeLoadingBuilder signature (usable as tear-off)',
+        () {
+          final WebviewtubeLoadingBuilder builder =
+              WebviewtubeDefaults.loadingBuilder;
+          expect(builder, isNotNull);
+        },
+      );
+    });
+
+    group('controlsBuilder', () {
+      test(
+        'matches WebviewtubeControlsBuilder signature (usable as tear-off)',
+        () {
+          final WebviewtubeControlsBuilder builder =
+              WebviewtubeDefaults.controlsBuilder;
+          expect(builder, isNotNull);
+        },
+      );
+    });
+
+    group('progressBarBuilder', () {
+      test(
+        'matches WebviewtubeProgressBarBuilder signature (usable as tear-off)',
+        () {
+          final WebviewtubeProgressBarBuilder builder =
+              WebviewtubeDefaults.progressBarBuilder;
+          expect(builder, isNotNull);
+        },
+      );
+    });
+
+    test('is reachable via the public package barrel', () {
+      expect(public.WebviewtubeDefaults.loadingBuilder, isNotNull);
+      expect(public.WebviewtubeDefaults.controlsBuilder, isNotNull);
+      expect(public.WebviewtubeDefaults.progressBarBuilder, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
The new builder API on `WebviewtubeVideoPlayer` (`loadingBuilder`, `controlsBuilder`, `progressBarBuilder`) was unusable for partial customization: the internal widgets the defaults compose (e.g. `DurationIndicator`, `VolumeButton`) are not part of the public API, so a consumer who wanted to wrap or extend the defaults had to rewrite the entire overlay from scratch.

This change exposes the default overlay implementations as static methods on a new public class, `WebviewtubeDefaults`. Consumers can now:

- Pass a default as a tear-off:

  ```dart WebviewtubeVideoPlayer( videoId: '...', loadingBuilder: WebviewtubeDefaults.loadingBuilder, ); ```

- Compose with the default inside their own builder:

  ```dart controlsBuilder: (ctx, state) => Stack( clipBehavior: Clip.none, children: [ WebviewtubeDefaults.controlsBuilder(ctx, state, color: Colors.red), const Positioned(right: 10, bottom: -5, child: MyExtraButton()), ], ); ```

The leaf widgets (`DurationIndicator` etc.) stay private and remain free to refactor; only the assembled default builders are part of the supported surface.

Changes:

- Lift the three private `_default*` functions into static methods on a new `WebviewtubeDefaults` class, with named optional `color`/`style` parameters.
- Add `WebviewtubeDefaults` to the `show` clause in `lib/src/webviewtube.dart`.
- Add tests covering each method, tear-off-signature compatibility, and reachability through the public package barrel.